### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-azure-mgmt-datafactory~=0.12.0
-azure-mgmt-resource~=10.2.0
-azure-storage-blob~=12.4.0
-pandas~=1.1.1
-pyodbc~=4.0.30
-python-dotenv~=0.15.0
+azure-mgmt-datafactory>=0.12.0
+azure-mgmt-resource>=10.2.0
+azure-storage-blob>=12.4.0
+pandas>=1.1.1
+pyodbc>=4.0.30
+python-dotenv>=0.15.0
 pytest
-PyYAML~=5.3
-sqlalchemy~=1.3.19
+PyYAML>=5.3
+sqlalchemy>=1.3.19


### PR DESCRIPTION
@melvinfolkers wij hebben nu aantal versies vast gezet, zoals `pandas~=1.1.1` en numpy, maar inmiddels is pandas 1.2.1 al uit bijvoorbeeld. Vandaar overal `>=` van gemaakt.