### PR TITLE
Create container fix

### DIFF
--- a/df_to_azure/adf.py
+++ b/df_to_azure/adf.py
@@ -79,12 +79,13 @@ def create_blob_service_client():
     return blob_service_client
 
 
-def create_blob_container():
+def create_blob_container(container_name: str):
     blob_service_client = create_blob_service_client()
-    try:
-        blob_service_client.create_container("dftoazure")
-    except:
-        logging.info("CreateContainerError: Container already exists.")
+    containers = [x.get("name") for x in blob_service_client.list_containers()]
+    if container_name not in containers:
+        blob_service_client.create_container(name=container_name)
+    else:
+        logging.debug(f"Container {container_name} already exists.")
 
 
 def create_linked_service_sql():

--- a/df_to_azure/export.py
+++ b/df_to_azure/export.py
@@ -42,12 +42,12 @@ def run_multiple(
         # azure components
         adf.create_resourcegroup()
         adf.create_datafactory()
-        adf.create_blob_container()
 
         # linked services
         adf.create_linked_service_sql()
         adf.create_linked_service_blob()
 
+    adf.create_blob_container(container_name="dftoazure")
     for table in tables:
 
         upload_dataset(table)
@@ -82,12 +82,11 @@ def run(
         # azure components
         adf.create_resourcegroup()
         adf.create_datafactory()
-        adf.create_blob_container()
 
         # linked services
         adf.create_linked_service_sql()
         adf.create_linked_service_blob()
-
+    adf.create_blob_container(container_name="dftoazure")
     upload_dataset(table)
     adf.create_input_blob(table)
     adf.create_output_sql(table)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pandas~=1.2.3
 pyodbc~=4.0.30
 pytest
 sqlalchemy~=1.4.0
-git+ssh://git@github.com/zypp-io/keyvault.git
+keyvault


### PR DESCRIPTION
closes #91 

The problem was not necessarily the container creation, since the environment variable `create = True` should be added when running the first time.

I think we should change the package eventually that it will always check if a certain resource exists (data factory, containers, maybe even data factory linked services). In this pull request i at least made the check on the container part of the regular flow (even if environment setting create is not set to True). 

