### PR TITLE
Improve linked service

### DIFF
--- a/df_to_azure/adf.py
+++ b/df_to_azure/adf.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from re import sub
 from typing import Union
 
 from azure.identity import ClientSecretCredential
@@ -50,9 +51,9 @@ class ADF(TableParameters):
         self.ls_blob_account_name = os.environ.get("ls_blob_account_name")
         self.rg_name = os.environ.get("rg_name")
         self.df_name = os.environ.get("df_name")
-        self.ls_sql_name = (
-            f'server={os.environ.get("SQL_SERVER").replace(".", "-")} '
-            f'database={os.environ.get("SQL_DB").replace("_","-")}'
+        self.ls_sql_name = "server={} database={}".format(
+            sub("[<>*#.%&:\\\\+?/]", "-", os.environ.get("SQL_SERVER")),
+            sub("[<>*#.%&:\\\\+?/]", "-", os.environ.get("SQL_DB")),
         )
         self.ls_blob_name = f'accountname={os.environ.get("ls_blob_account_name")}'
         self.create = create

--- a/df_to_azure/adf.py
+++ b/df_to_azure/adf.py
@@ -17,6 +17,7 @@ from azure.mgmt.datafactory.models import (
     DependencyCondition,
     Factory,
     LinkedServiceReference,
+    LinkedServiceResource,
     PipelineResource,
     SecureString,
     SqlServerStoredProcedureActivity,
@@ -49,8 +50,11 @@ class ADF(TableParameters):
         self.ls_blob_account_name = os.environ.get("ls_blob_account_name")
         self.rg_name = os.environ.get("rg_name")
         self.df_name = os.environ.get("df_name")
-        self.ls_sql_name = "Python SQL Linked Service"
-        self.ls_blob_name = "Python Blob Linked Service"
+        self.ls_sql_name = (
+            f'server={os.environ.get("SQL_SERVER").replace(".", "-")} '
+            f'database={os.environ.get("SQL_DB").replace("_","-")}'
+        )
+        self.ls_blob_name = f'accountname={os.environ.get("ls_blob_account_name")}'
         self.create = create
 
     @staticmethod
@@ -142,7 +146,7 @@ class ADF(TableParameters):
             f";password={os.environ.get('SQL_PW')}"
         )
 
-        ls_azure_sql = AzureSqlDatabaseLinkedService(connection_string=conn_string)
+        ls_azure_sql = LinkedServiceResource(properties=AzureSqlDatabaseLinkedService(connection_string=conn_string))
 
         self.adf_client.linked_services.create_or_update(
             self.rg_name,
@@ -157,7 +161,7 @@ class ADF(TableParameters):
             f";AccountKey={os.environ.get('ls_blob_account_key')}"
         )
 
-        ls_azure_blob = AzureStorageLinkedService(connection_string=storage_string)
+        ls_azure_blob = LinkedServiceResource(properties=AzureStorageLinkedService(connection_string=storage_string))
         self.adf_client.linked_services.create_or_update(
             self.rg_name,
             self.df_name,

--- a/df_to_azure/export.py
+++ b/df_to_azure/export.py
@@ -300,7 +300,7 @@ class DfToParquet:
             the folder + filename structure for uploading the dataset.
         """
         if method == "create":
-            name = f"{folder}/{self.tablename}/{self.tablename}.parquet"
+            name = f"{folder}/{self.tablename}.parquet"
         elif method == "append":
             name = f"{folder}/{self.tablename}/{self.tablename}_{datetime.now().strftime('%Y%m%d%H%M%S')}.parquet"
         else:

--- a/df_to_azure/export.py
+++ b/df_to_azure/export.py
@@ -90,9 +90,9 @@ class DfToAzure(ADF):
             self.create_datafactory()
             self.create_blob_container()
 
-            # linked services
-            self.create_linked_service_sql()
-            self.create_linked_service_blob()
+        # linked services
+        self.create_linked_service_sql()
+        self.create_linked_service_blob()
 
         self.upload_dataset()
         self.create_input_blob()
@@ -279,7 +279,7 @@ class DfToParquet:
         self.df = df
         self.tablename = tablename
         self.upload_name = self.set_upload_name(folder, method)
-        self.connection_string = self.set_connection_string()
+        self.connection_string = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
 
     def set_upload_name(self, folder: str, method: str) -> str:
         """
@@ -306,22 +306,6 @@ class DfToParquet:
         else:
             raise ValueError(f"No valid method given: {method}. choose create or append.")
         return name
-
-    @staticmethod
-    def set_connection_string() -> str:
-        """
-        sets the connection string based on the blob account name and the blob account key.
-
-        Returns
-        -------
-        connection_str: str
-            the connection string for the Azure storage account.
-        """
-        connect_str = (
-            f"DefaultEndpointsProtocol=https;AccountName={os.environ.get('ls_blob_account_name')}"
-            f";AccountKey={os.environ.get('ls_blob_account_key')};"
-        )
-        return connect_str
 
     def run(self):
 


### PR DESCRIPTION
changes in this pull request:

- always create linked services for blob and sql. This way the user can switch source blob storages and sink databases easier.
- use environment variable AZURE_STORAGE_CONNECTION_STRING for parquet upload
- if parquet upload is a single file, place it in the root of the folder