### PR TITLE
BUG: python exits if no df is empty

### DIFF
--- a/df_to_azure/export.py
+++ b/df_to_azure/export.py
@@ -97,6 +97,11 @@ class DfToAzure(ADF):
         self.clean_staging = clean_staging
 
     def run(self):
+
+        if self.df.empty:
+            logging.info("Data empty, no new records to upload.")
+            return None, None
+
         if self.create:
 
             # azure components
@@ -133,10 +138,6 @@ class DfToAzure(ADF):
                 WrongDtypeError("Wrong dtype given, only SqlAlchemy types are accepted")
 
     def upload_dataset(self):
-
-        if self.df.empty:
-            logging.info("Data empty, no new records to upload.")
-            sys.exit(1)
 
         if self.method == "create":
             self.create_schema()

--- a/df_to_azure/export.py
+++ b/df_to_azure/export.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 from datetime import datetime
 from io import BytesIO
 from typing import Union

--- a/df_to_azure/tests/test_general.py
+++ b/df_to_azure/tests/test_general.py
@@ -213,12 +213,8 @@ def test_dataframe_with_no_data():
     results = list()
 
     for df in df_list:
-        r = df_to_azure(df, tablename="no_data", schema="test")
+        r = df_to_azure(df, tablename=f"dataset_{df.shape[0]}_records", schema="test")
         results.append(r)
 
     # there should be 2 results from the 2 df_to_azure operations.
     assert len(results) == 2
-
-
-if __name__ == "__main__":
-    test_dataframe_with_no_data()

--- a/df_to_azure/tests/test_general.py
+++ b/df_to_azure/tests/test_general.py
@@ -203,3 +203,22 @@ def test_double_column_names():
             schema="test",
             wait_till_finished=True,
         )
+
+
+def test_dataframe_with_no_data():
+
+    # scenario where there are 2 dataframes, first one empty and the second one with data.
+    df_list = [DataFrame(), DataFrame({"A": [1, 2, 3], "B": [10, 20, 30], "C": ["X", "Y", "Z"]})]
+
+    results = list()
+
+    for df in df_list:
+        r = df_to_azure(df, tablename="no_data", schema="test")
+        results.append(r)
+
+    # there should be 2 results from the 2 df_to_azure operations.
+    assert len(results) == 2
+
+
+if __name__ == "__main__":
+    test_dataframe_with_no_data()


### PR DESCRIPTION
I've ran into an issue where df_to_azure makes the python code exit when the dataframe is empty.

This makes the python script exit, which is undesired. A better solution in my opinion would be to simply return None. i have written a test that shows the problem (and fails). In this suggested solution the validation for checking if the dataframe is empty is moved up.
