### PR TITLE
ENH: Make driver dynamic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.10]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -28,12 +28,6 @@ jobs:
     - name: Run pre-commit
       run: |
         pre-commit run --all-files
-    - name: assert equality between setup.cfg and requirements.txt
-      uses: actions/checkout@v2
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
     - name: execute py script
       run: |
         python ./scripts/check_setupcfg_and_requirements_equal.py

--- a/df_to_azure/db.py
+++ b/df_to_azure/db.py
@@ -71,7 +71,14 @@ class SqlUpsert:
                 )
 
 
-def auth_azure(driver: str = "ODBC Driver 17 for SQL Server"):
+def auth_azure(driver: str = None):
+
+    if driver is None:
+        import pyodbc
+        try:
+            driver = pyodbc.drivers()[-1]
+        except IndexError:
+            raise ValueError("ODBC driver not found")
 
     connection_string = "mssql+pyodbc://{}:{}@{}:1433/{}?driver={}".format(
         os.environ.get("SQL_USER"),

--- a/df_to_azure/db.py
+++ b/df_to_azure/db.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql import text
 
-from df_to_azure.exceptions import UpsertError
+from df_to_azure.exceptions import DriverError, UpsertError
 
 
 class SqlUpsert:
@@ -80,7 +80,7 @@ def auth_azure(driver: str = None):
         try:
             driver = pyodbc.drivers()[-1]
         except IndexError:
-            raise ValueError("ODBC driver not found")
+            raise DriverError("ODBC driver not found")
 
     connection_string = "mssql+pyodbc://{}:{}@{}:1433/{}?driver={}".format(
         os.environ.get("SQL_USER"),

--- a/df_to_azure/db.py
+++ b/df_to_azure/db.py
@@ -4,6 +4,7 @@ from urllib.parse import quote_plus
 
 from sqlalchemy import create_engine
 from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.sql import text
 
 from df_to_azure.exceptions import UpsertError
 
@@ -75,6 +76,7 @@ def auth_azure(driver: str = None):
 
     if driver is None:
         import pyodbc
+
         try:
             driver = pyodbc.drivers()[-1]
         except IndexError:
@@ -105,6 +107,5 @@ def execute_stmt(stmt: str):
 
     """
     with auth_azure() as con:
-        t = con.begin()
-        con.execute(stmt)
-        t.commit()
+        with con.begin():
+            con.execute(text(stmt))

--- a/df_to_azure/exceptions.py
+++ b/df_to_azure/exceptions.py
@@ -34,3 +34,9 @@ class UpsertError(Exception):
     """For the moment upsert gives an error"""
 
     pass
+
+
+class DriverError(Exception):
+    """Can't find correct odbc driver"""
+
+    pass

--- a/df_to_azure/tests/test_general.py
+++ b/df_to_azure/tests/test_general.py
@@ -204,15 +204,3 @@ def test_double_column_names():
             schema="test",
             wait_till_finished=True,
         )
-
-
-def test_driver_import():
-    import sys
-
-    # Before we run auth_azure, pyodbc should not be imported
-    assert "pyodbc" not in sys.modules
-    with auth_azure() as con:
-        # Now it should be
-        assert "pyodbc" in sys.modules
-
-    return con

--- a/df_to_azure/tests/test_general.py
+++ b/df_to_azure/tests/test_general.py
@@ -204,3 +204,11 @@ def test_double_column_names():
             schema="test",
             wait_till_finished=True,
         )
+
+
+def test_driver_import():
+    import sys
+    with auth_azure() as con:
+        assert "pyodbc" in sys.modules
+
+    with py

--- a/df_to_azure/tests/test_general.py
+++ b/df_to_azure/tests/test_general.py
@@ -208,7 +208,11 @@ def test_double_column_names():
 
 def test_driver_import():
     import sys
+
+    # Before we run auth_azure, pyodbc should not be imported
+    assert "pyodbc" not in sys.modules
     with auth_azure() as con:
+        # Now it should be
         assert "pyodbc" in sys.modules
 
-    with py
+    return con


### PR DESCRIPTION
Right now the driver is hardcoded to version 17 ODBC. This pr makes it generic by calling the `pyodbc.drivers` method and getting the last one.